### PR TITLE
Added more Logging Capabilities in Install.ps1 and Uninstall.ps1 and added error handling in Create-Win32App.ps1

### DIFF
--- a/Create-Win32App.ps1
+++ b/Create-Win32App.ps1
@@ -170,7 +170,7 @@ process {
             # Find GUID in UninstallCommand:
             if ($msiGUIDjson.Equals($msiID)) {
                 # All Good Uninstall String matches the UID of the .msi file
-                Write-Verbose"Uninstall String matches GUID from MSI packet. Your Uninstall String: $($msiGUIDjson.GUID). The MSI ID: $($msiID.GUID)"
+                Write-Verbose "Uninstall String matches GUID from MSI packet. Your Uninstall String: $($msiGUIDjson.GUID). The MSI ID: $($msiID.GUID)"
             } else {
                 # We have a problem:
                 Write-Host "Warning you've a Uninstall String specified which does not matches the UID of the .msi File. Maybe this change come by an Update."

--- a/Create-Win32App.ps1
+++ b/Create-Win32App.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -RunAsAdministrator
+#Requires -RunAsAdministrator
 <#
     .SYNOPSIS
         Create a Win32 app in Microsoft Intune based on input from app manifest file.
@@ -17,10 +17,11 @@
         Author:      Nickolaj Andersen
         Contact:     @NickolajA
         Created:     2020-09-26
-        Updated:     2020-09-26
+        Updated:     2022-12-29
 
         Version history:
         1.0.0 - (2020-09-26) Script created
+        1.0.1 - (2022-12-29) - Errorhandling if Install.ps1 or Uninstall.ps1 is missing source folder
 
         Updated for Evergreen integration to create a package factory
         Aaron Parker, @stealthpuppy
@@ -83,6 +84,24 @@ process {
         if (Test-Path -Path $(Join-Path -Path $SourceFolder -ChildPath $AppData.PackageInformation.SetupFile)) {}
         else {
             throw "Cannot find $(Join-Path -Path $SourceFolder -ChildPath $AppData.PackageInformation.SetupFile)"
+        }
+
+        # Check for the install.ps1 if specified in app.json
+        # if it does not exist in source folder, we copy it from base dir .\
+        if ($AppData.Program.InstallTemplate.Contains("Install.ps1") -or $AppData.Program.InstallCommand.Contains("Install.ps1")) {
+            if (Test-Path -Path $(Join-Path -Path $SourceFolder -ChildPath "Install.ps1")) {} else {
+                Write-Verbose "Install.ps1 used in app.json but not found in sourcefolder. Copy it from Template .\ to $sourceFolder"
+                Copy-Item -Path "Install.ps1" -Destination $SourceFolder 
+            }
+        }
+
+        # Check for the Uninstall.ps1 if specified in app.json
+        # if it does not exist in source folder, we copy it from base dir .\
+        if ($AppData.Program.InstallTemplate.Contains("Install.ps1") -or $AppData.Program.InstallCommand.Contains("Uninstall.ps1")) {
+            if (Test-Path -Path $(Join-Path -Path $SourceFolder -ChildPath "Uninstall.ps1")) {} else {
+                Write-Verbose "Uninstall.ps1 used in app.json but not found in sourcefolder. Copy it from Template .\ to $sourceFolder"
+                Copy-Item -Path "Uninstall.ps1" -Destination $SourceFolder 
+            }
         }
 
         # Remove existing intunewin files

--- a/Install.ps1
+++ b/Install.ps1
@@ -1,11 +1,26 @@
 <#
-    .SYNOPSIS
-    Installs an application based on logic defined in Install.json
+ # File: c:\dev\intunepacketfactory\packages\Apps\Filezilla\Source\Install.ps1
+ # Project: c:\dev\intunepacketfactory\packages\Apps\Filezilla\Source
+ # Created Date: Thursday, December 29th 2022, 8:59:14 am
+ # Author: Aaron Parker
+ # -----
+ # Description: Installs an application based on logic defined in Install.json
+ # -----
+ # Last Modified: Thu Dec 29 2022
+ # Modified By: Constantin Lotz
+ # -----
+ # 
+ #  
+ # -----
+ # HISTORY:
+ # Date      	By	Comments
+ # ----------	---	----------------------------------------------------------
+ # 2022-12-29	CL	added more logging capabilitys for the script itself 
+ # 2022-12-29	AP  initial	
+ #>
 
-    .NOTES
-    Version: 1.0
-    Date: 13th September 2022
-#>
+
+
 [CmdletBinding(SupportsShouldProcess = $True)]
 param ()
 
@@ -25,6 +40,52 @@ if (!([System.Environment]::Is64BitProcess)) {
     }
 }
 #endregion
+
+$logging = $true;
+$global:logfile = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\Installps1.log";
+
+# Logging Function 
+function Write-Feedback()
+{
+    param
+    (
+        [Parameter(Position=0,ValueFromPipeline=$true,Mandatory=$true)]
+        [string]$msg,
+        [Parameter(Position=1,ValueFromPipeline=$true,Mandatory=$false)]
+        [switch]$logOnly,
+        [Parameter(Position=2,ValueFromPipeline=$true,Mandatory=$false)]
+        [string]$severity
+    )
+
+	# Call Example:
+	# $logtime = get-date -format 'dd.MM.yyyy;HH:mm:ss'
+	# Write-Feedback "$logtime - Info:Frage TFK Settings ab. User: $($phoneExtension) - AutoLogoffEnabled: $($userSettings.serviceAutoLogoffEnabled)"
+	
+    # Datei leeren wenn größer 50MB
+    if ((Test-Path -Path $logfile) -eq $true) {
+        If ((Get-Item $logfile).length -gt 50mb) {
+            Clear-Content $global:logfile
+            $logtime = get-date -format 'dd.MM.yyyy;HH:mm:ss'
+            $msg = "$logtime - " + "Info" + ":" + "Logfile geleert, da größer als 50MB."
+        }
+    }
+    
+    # Wenn Schweregrad angegeben dann baue String korrekt
+    if (![string]::IsNullOrEmpty($severity)) {
+        $logtime = get-date -format 'dd.MM.yyyy;HH:mm:ss'
+        $msg = "$logtime - " + $severity + ":" + $msg
+    }
+
+    # Nur In Datei loggen, aber nicht in Konsole
+    if($logOnly.IsPresent)  {
+        $msg | Out-File $global:logfile -Append
+    } else {
+        Write-Host $msg;
+        $msg | Out-File $global:logfile -Append
+    }
+	
+}
+
 
 #region Functions
 function Get-InstallConfig {
@@ -70,6 +131,8 @@ function Copy-File {
                     $FilePath = Get-ChildItem -Path $Path -Filter $Item.Source -Recurse -ErrorAction "SilentlyContinue"
                     Write-Verbose -Message "Source: $($FilePath.FullName)"
                     Write-Verbose -Message "Destination: $($Item.Destination)"
+                    if ($logging) { Write-Feedback "Copy-File: Source: $($FilePath.FullName)" -severity "Info" -logOnly }
+                    if ($logging) { Write-Feedback "Copy-File: Destination: $($Item.Destination)" -severity "Info" -logOnly }
                     $params = @{
                         Path        = $FilePath.FullName
                         Destination = $Item.Destination
@@ -79,10 +142,12 @@ function Copy-File {
                     Copy-Item @params
                 }
                 catch {
+                    if ($logging) { Write-Feedback "Copy-File: $($_)" -severity "Error" -logOnly }
                     throw $_
                 }
             }
             else {
+                if ($logging) { Write-Feedback "Copy-File: Cannot find destination: $($Item.Destination)" -severity "Error" -logOnly }
                 throw "Cannot find destination: $($Item.Destination)"
             }
         }
@@ -132,15 +197,18 @@ function Stop-PathProcess {
         foreach ($Item in $Path) {
             try {
                 if ($PSBoundParameters.ContainsKey("Force")) {
+                    if ($logging) { Write-Feedback "Stop-PathProcess Stop-Process where Path like: $($Item)" -severity "Info" -logOnly }
                     Get-Process | Where-Object { $_.Path -like $Item } | `
                         Stop-Process -Force -ErrorAction "SilentlyContinue"
                 }
                 else {
+                    if ($logging) { Write-Feedback "Stop-PathProcess Stop-Process where Path like: $($Item)" -severity "Info" -logOnly }
                     Get-Process | Where-Object { $_.Path -like $Item } | `
                         Stop-Process -ErrorAction "SilentlyContinue"
                 }
             }
             catch {
+                if ($logging) { Write-Feedback "Stop-PathProcess Error: $($_.Exception.Message)" -severity "Warning" -logOnly }
                 Write-Warning -Message $_.Exception.Message
             }
         }
@@ -181,7 +249,19 @@ function Uninstall-Msi {
 # Get the install details for this application
 $Install = Get-InstallConfig
 $Installer = Get-Installer -File $Install.PackageInformation.SetupFile
+
+# Define Logging for this PS
+if ([System.String]::IsNullOrEmpty($Install.LogPath) -eq $false) {
+	if ([System.String]::IsNullOrEmpty($Install.PackageInformation.SetupFile)) { 
+		$global:logfile = "$($Install.LogPath)" + "\" + "Installps1.log"
+	} else {
+        $global:logfile = "$($Install.LogPath)" + "\" + $($Install.PackageInformation.SetupFile) + "_Installps1.log"
+    }
+}
+
+
 if ([System.String]::IsNullOrEmpty($Installer)) {
+	if ($logging) { Write-Feedback "File not found: $($Install.PackageInformation.SetupFile)" -severity "Error" -logOnly }
     throw "File not found: $($Install.PackageInformation.SetupFile)"
     exit 1
 }
@@ -189,9 +269,11 @@ else {
     # Create the log folder
     if (Test-Path -Path $Install.LogPath -PathType "Container") {
         Write-Verbose -Message "Directory exists: $($Install.LogPath)"
+        if ($logging) { Write-Feedback "Directory exists: $($Install.LogPath)" -severity "Info" -logOnly }
     }
     else {
         Write-Verbose -Message "Create directory: $($Install.LogPath)"
+        if ($logging) { Write-Feedback "Create directory: $($Install.LogPath)" -severity "Info" -logOnly }
         New-Item -Path $Install.LogPath -ItemType "Directory" -ErrorAction "SilentlyContinue" | Out-Null
     }
 
@@ -214,6 +296,8 @@ else {
             "EXE" {
                 Write-Verbose -Message "Installer: $Installer"
                 Write-Verbose -Message "ArgumentList: $ArgumentList"
+                if ($logging) { Write-Feedback "Installer: $Installer" -severity "Info" -logOnly }
+                if ($logging) { Write-Feedback "ArgumentList: $ArgumentList" -severity "Info" -logOnly }
                 $params = @{
                     FilePath     = $Installer
                     ArgumentList = $ArgumentList
@@ -228,6 +312,8 @@ else {
             "MSI" {
                 Write-Verbose -Message "Installer: $Env:SystemRoot\System32\msiexec.exe"
                 Write-Verbose -Message "ArgumentList: $ArgumentList"
+                if ($logging) { Write-Feedback "Installer: $Env:SystemRoot\System32\msiexec.exe" -severity "Info" -logOnly }
+                if ($logging) { Write-Feedback "ArgumentList: $ArgumentList" -severity "Info" -logOnly }
                 $params = @{
                     FilePath     = "$Env:SystemRoot\System32\msiexec.exe"
                     ArgumentList = $ArgumentList
@@ -240,6 +326,7 @@ else {
                 }
             }
             default {
+                if ($logging) { Write-Feedback "$($Install.PackageInformation.SetupType) not found in the supported setup types - EXE, MSI." -severity "Error" -logOnly }
                 throw "$($Install.PackageInformation.SetupType) not found in the supported setup types - EXE, MSI."
                 exit 1
             }
@@ -261,6 +348,7 @@ else {
     }
     finally {
         if ($Install.PostInstall.Remove.Count -gt 0) { Remove-Path -Path $Install.PostInstall.Remove }
+        if ($logging) { Write-Feedback "Exit Code: $($result.ExitCode)" -severity "Info" -logOnly }
         exit $result.ExitCode
     }
 }

--- a/Uninstall.ps1
+++ b/Uninstall.ps1
@@ -1,0 +1,129 @@
+<#
+ # File: c:\dev\intunepacketfactory\packages\Apps\Filezilla\Source\Install.ps1
+ # Project: c:\dev\intunepacketfactory\packages\Apps\Filezilla\Source
+ # Created Date: Thursday, December 29th 2022, 8:59:14 am
+ # Author: Aaron Parker
+ # -----
+ # Description: Uninstalls the Application
+ # -----
+ # Last Modified: Thu Dec 29 2022
+ # Modified By: Constantin Lotz
+ # -----
+ # 
+ #  
+ # -----
+ # HISTORY:
+ # Date      	By	Comments
+ # ----------	---	----------------------------------------------------------
+ # 2022-12-29	CL	added more logging capabilitys for the script itself 
+ # 2022-12-29	AP  initial	
+ #>
+
+[CmdletBinding()]
+param ()
+
+#region Restart if running in a 32-bit session
+if (!([System.Environment]::Is64BitProcess)) {
+    if ([System.Environment]::Is64BitOperatingSystem) {
+        $Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$($MyInvocation.MyCommand.Definition)`""
+        $ProcessPath = $(Join-Path -Path $Env:SystemRoot -ChildPath "\Sysnative\WindowsPowerShell\v1.0\powershell.exe")
+        $params = @{
+            FilePath     = $ProcessPath
+            ArgumentList = $Arguments
+            Wait         = $True
+            WindowStyle  = "Hidden"
+        }
+        Start-Process @params
+        exit 0
+    }
+}
+#endregion
+
+# Define Params here
+$uninstaller            = "$env:ProgramFiles\FileZilla FTP Client\uninstall.exe"
+$uninstallerArguments   = "/S"
+$setupLocation          = "$env:ProgramFiles\FileZilla FTP Client" # No Ending Trail
+
+# Logging Function 
+$logging = $true;
+$global:logfile = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\Uninstallps1.log";
+
+function Write-Feedback()
+{
+    param
+    (
+        [Parameter(Position=0,ValueFromPipeline=$true,Mandatory=$true)]
+        [string]$msg,
+        [Parameter(Position=1,ValueFromPipeline=$true,Mandatory=$false)]
+        [switch]$logOnly,
+        [Parameter(Position=2,ValueFromPipeline=$true,Mandatory=$false)]
+        [string]$severity
+    )
+
+	# Call Example:
+	# $logtime = get-date -format 'dd.MM.yyyy;HH:mm:ss'
+	# Write-Feedback "$logtime - Info:Frage TFK Settings ab. User: $($phoneExtension) - AutoLogoffEnabled: $($userSettings.serviceAutoLogoffEnabled)"
+	
+    # Datei leeren wenn größer 50MB
+    if ((Test-Path -Path $logfile) -eq $true) {
+        If ((Get-Item $logfile).length -gt 50mb) {
+            Clear-Content $global:logfile
+            $logtime = get-date -format 'dd.MM.yyyy;HH:mm:ss'
+            $msg = "$logtime - " + "Info" + ":" + "Logfile geleert, da größer als 50MB."
+        }
+    }
+    
+    # Wenn Schweregrad angegeben dann baue String korrekt
+    if (![string]::IsNullOrEmpty($severity)) {
+        $logtime = get-date -format 'dd.MM.yyyy;HH:mm:ss'
+        $msg = "$logtime - " + $severity + ":" + $msg
+    }
+
+    # Nur In Datei loggen, aber nicht in Konsole
+    if($logOnly.IsPresent)  {
+        $msg | Out-File $global:logfile -Append
+    } else {
+        Write-Host $msg;
+        $msg | Out-File $global:logfile -Append
+    }
+	
+}
+### End Logging Function
+
+
+
+try {
+    if ($logging) { Write-Feedback "Try stopping Processes....." -severity "Info" -logOnly }
+    Get-Process -ErrorAction "SilentlyContinue" | `
+        Where-Object { $_.Path -like "$setupLocation\*" } | `
+        Stop-Process -Force -ErrorAction "SilentlyContinue"
+}
+catch {
+    Write-Warning -Message "Failed to stop processes."
+    if ($logging) { Write-Feedback "Failed to stop processes." -severity "Error" -logOnly }
+}
+
+try {
+    $params = @{
+        FilePath     = "$uninstaller"
+        ArgumentList = "$uninstallerArguments"
+        NoNewWindow  = $True
+        PassThru     = $True
+        Wait         = $True
+    }
+
+    if ($logging) { Write-Feedback "Removing Programm: $uninstaller" -severity "Info" -logOnly }
+    if ($logging) { Write-Feedback "Removing Parameters: $uninstallerArguments" -severity "Info" -logOnly }
+    $result = Start-Process @params
+    if ($logging) { Write-Feedback "Exit Code: $($result.ExitCode)" -severity "Info" -logOnly }
+    if ($result.ExitCode -eq 0) {
+        Remove-Item -Path $setupLocation -Recurse  -ErrorAction SilentlyContinue
+        if ($logging) { Write-Feedback "Removing Programm File Location: $setupLocation" -severity "Info" -logOnly }
+    }
+}
+catch {
+    throw $_
+}
+finally {
+    exit $result.ExitCode
+}


### PR DESCRIPTION
Hi Aaron,

I thought it would be nice to have a separat log file for the run in install.ps1 and uninstall.ps1 for troubleshooting. Looking in the own Log files is much easier than using the intune default, so i've added a bit - hope you like it.

Aswell in Create-Win32App i've added error handling if you specify a Install.ps1 in the app.json but the file is not in the source folder, so the package will be created without and intune will run in an issue, because it could not execute sth :-)

So if we can now additionally specify an custom-setup.ps1 or sth. like that in the install.json to run additional setup/modifications, we can leave the install.ps1 for most packages default. Same we could overthink with the uninstall process. this could be aswell specified in the install.json and the uninstaller.ps1 will use that params out there.

Aswell for msi packages we could use automated GUID extraction for the Uninstallation command msiexec /x - to avoid mistakes from user input and so one.
Damn so many ideas, sorry for writing a book ;-)

Kind regards,
Constantin