### PR TITLE
Update Update-PackageJson.ps1

### DIFF
--- a/scripts/Update-PackageJson.ps1
+++ b/scripts/Update-PackageJson.ps1
@@ -1,4 +1,6 @@
 #Requires -Modules Evergreen, VcRedist
+#Requires -Version 6.0
+# Notice: Requires Powershell 6+ (due to ConvertFrom-JSON -DEPTH Parameter Usage)
 <#
     Update the App.json for packages
 #>
@@ -41,7 +43,7 @@ foreach ($ManifestJson in $ManifestList) {
         Write-Warning -Message "Error reading $($ManifestJson.FullName) with: $($_.Exception.Message)"
     }
 
-    if ($null -eq $Manifest.Application.Filter) {
+    if ([System.String]::IsNullOrEmpty($Manifest.Application.Filter)) {
         Write-Host -ForegroundColor "Cyan" "Not supported for automatic update: $($ManifestJson.FullName)."
     }
     else {


### PR DESCRIPTION
Error Handling when Custom App with no Filter is provided  Requires Powershell 6+ due to usage of convertfrom-json -depth usage. Is not really nice since New-Win32Package requires 5.1 Desktop version, so we have to switch versions  :-)