### PR TITLE
Update New-Win32Package.ps1

### DIFF
--- a/New-Win32Package.ps1
+++ b/New-Win32Package.ps1
@@ -238,8 +238,13 @@ process {
 
                     # Download the application installer via Evergreen and download
                     Write-Msg -Msg "Invoke filter: '$($Manifest.Application.Filter)'"
-                    Write-Msg -Msg "Downloading to: '$SourcePath'"
-                    $Result = Invoke-Expression -Command $Manifest.Application.Filter | Save-EvergreenApp -CustomPath $SourcePath
+                    if ($($Manifest.Application.Filter) -match "Evergreen") {
+                        Write-Msg -Msg "Downloading with Evergreen to: '$SourcePath'"
+                        $Result = Invoke-Expression -Command $Manifest.Application.Filter | Save-EvergreenApp -CustomPath $SourcePath
+                    } else {
+                        Write-Msg -Msg "Executing Legacy Command: '$($Manifest.Application.Filter)'"
+                        Invoke-Expression -Command $Manifest.Application.Filter
+                    }
 
                     #region Unpack the installer file if its a zip file
                     foreach ($File in $Result) { Write-Msg -Msg "Downloaded: '$($File.FullName)'" }


### PR DESCRIPTION
Adds the option to use "custom" update commands or mechanism to get the latest files if Evergreen is not available.

Example for Filter:
"Filter": "Copy-Item \"\\\\SERVERNAME\\Folder\\Software\\*\" -Destination \"$SourcePath\\Software\\\" -Force -Recurse;"

So just checking if Evergreen is in the filter and else just run the command. Maybe there would be an check for null good:

} elseif (![String]::IsNullOrEmpty($Manifest.Application.Filter))  {
                        Write-Msg -Msg "Executing Legacy Command: '$($Manifest.Application.Filter)'"
                        Invoke-Expression -Command $Manifest.Application.Filter
                    }