### PR TITLE
Copy file

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -133,30 +133,24 @@ function Copy-File {
     )
     process {
         foreach ($Item in $File) {
-            if (Test-Path -Path $Item.Destination -PathType "Container") {
-                try {
-                    $FilePath = Get-ChildItem -Path $Path -Filter $Item.Source -Recurse -ErrorAction "Continue"
-                    Write-LogFile -Message "Copy-File: Source: $($FilePath.FullName)"
-                    Write-LogFile -Message "Copy-File: Destination: $($Item.Destination)"
-                    $params = @{
-                        Path        = $FilePath.FullName
-                        Destination = $Item.Destination
-                        Container   = $false
-                        Force       = $true
-                        ErrorAction = "Continue"
-                        WhatIf      = $Script:WhatIfPref
-                        Verbose     = $Script:VerbosePref
-                    }
-                    Copy-Item @params
+            try {
+                $FilePath = Get-ChildItem -Path $Path -Filter $Item.Source -Recurse -ErrorAction "Continue"
+                Write-LogFile -Message "Copy-File: Source: $($FilePath.FullName)"
+                Write-LogFile -Message "Copy-File: Destination: $($Item.Destination)"
+                $params = @{
+                    Path        = $FilePath.FullName
+                    Destination = $Item.Destination
+                    Container   = $false
+                    Force       = $true
+                    ErrorAction = "Continue"
+                    WhatIf      = $Script:WhatIfPref
+                    Verbose     = $Script:VerbosePref
                 }
-                catch {
-                    Write-LogFile -Message "Copy-File: $($_.Exception.Message)" -LogLevel 3
-                    Write-Warning -Message $_.Exception.Message
-                }
+                Copy-Item @params
             }
-            else {
-                Write-LogFile -Message "Copy-File: Cannot find destination: $($Item.Destination)" -LogLevel 3
-                Write-Warning -Message "Cannot find destination: $($Item.Destination)"
+            catch {
+                Write-LogFile -Message "Copy-File: $($_.Exception.Message)" -LogLevel 3
+                Write-Warning -Message $_.Exception.Message
             }
         }
     }

--- a/Install.ps1
+++ b/Install.ps1
@@ -237,16 +237,16 @@ function Stop-PathProcess {
 function Uninstall-Msi {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [System.String[]] $Caption,
+        [System.String[]] $ProductName,
         [System.String] $LogPath
     )
     process {
-        foreach ($Item in $Caption) {
+        foreach ($Item in $ProductName) {
             try {
-                $Product = Get-CimInstance -Class "Win32_Product" | Where-Object { $_.Caption -like $Item }
+                $Product = Get-CimInstance -Class "Win32_InstalledWin32Program" | Where-Object { $_.Name -like $Item }
                 $params = @{
                     FilePath     = "$Env:SystemRoot\System32\msiexec.exe"
-                    ArgumentList = "/uninstall `"$($Product.IdentifyingNumber)`" /quiet /log `"$LogPath\Uninstall-$($Item -replace " ").log`""
+                    ArgumentList = "/uninstall `"$($Product.MsiProductCode)`" /quiet /log `"$LogPath\Uninstall-$($Item -replace " ").log`""
                     NoNewWindow  = $true
                     PassThru     = $true
                     Wait         = $true
@@ -255,7 +255,7 @@ function Uninstall-Msi {
                     Verbose      = $Script:VerbosePref
                 }
                 $result = Start-Process @params
-                Write-LogFile -Message "$Env:SystemRoot\System32\msiexec.exe /uninstall `"$($Product.IdentifyingNumber)`" /quiet /log `"$LogPath\Uninstall-$($Item -replace " ").log`""
+                Write-LogFile -Message "$Env:SystemRoot\System32\msiexec.exe /uninstall `"$($Product.MsiProductCode)`" /quiet /log `"$LogPath\Uninstall-$($Item -replace " ").log`""
                 Write-LogFile -Message "Msiexec result: $($result.ExitCode)"
                 return $result.ExitCode
             }
@@ -295,7 +295,7 @@ else {
     if ($Install.InstallTasks.StopPath.Count -gt 0) { Stop-PathProcess -Path $Install.InstallTasks.StopPath }
 
     # Uninstall the application
-    if ($Install.InstallTasks.UninstallMsi.Count -gt 0) { Uninstall-Msi -Caption $Install.InstallTasks.UninstallMsi -LogPath $Install.LogPath }
+    if ($Install.InstallTasks.UninstallMsi.Count -gt 0) { Uninstall-Msi -ProductName $Install.InstallTasks.UninstallMsi -LogPath $Install.LogPath }
     if ($Install.InstallTasks.Remove.Count -gt 0) { Remove-Path -Path $Install.InstallTasks.Remove }
 
     # Create the log folder

--- a/Install.ps1
+++ b/Install.ps1
@@ -141,6 +141,7 @@ function Copy-File {
                     $params = @{
                         Path        = $FilePath.FullName
                         Destination = $Item.Destination
+                        Container   = $false
                         Force       = $true
                         ErrorAction = "Continue"
                         WhatIf      = $Script:WhatIfPref
@@ -359,7 +360,8 @@ else {
         if ($Install.PostInstall.StopPath.Count -gt 0) { Stop-PathProcess -Path $Install.PostInstall.StopPath }
 
         # Perform post install actions
-        if ($Install.PostInstall.Copy.Count -gt 0) { Copy-File -File $Install.PostInstall.Copy }
+        if ($Install.PostInstall.Remove.Count -gt 0) { Remove-Path -Path $Install.PostInstall.Remove }
+        if ($Install.PostInstall.CopyFile.Count -gt 0) { Copy-File -File $Install.PostInstall.CopyFile }
 
         # Execute run tasks
         if ($Install.PostInstall.Run.Count -gt 0) {
@@ -371,7 +373,6 @@ else {
         throw $_
     }
     finally {
-        if ($Install.PostInstall.Remove.Count -gt 0) { Remove-Path -Path $Install.PostInstall.Remove }
         Write-LogFile -Message "Install.ps1 complete. Exit Code: $($result.ExitCode)"
         exit $result.ExitCode
     }

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,7 +32,7 @@ You can replace the installation command with the [PowerShell App Deployment Too
     "PostInstall": {
         "Remove": [
         ],
-        "Copy": [
+        "CopyFile": [
         ]
     }
 }

--- a/packages/App/AdobeAcrobatReaderDCMUI/Source/Install.json
+++ b/packages/App/AdobeAcrobatReaderDCMUI/Source/Install.json
@@ -12,7 +12,7 @@
     "Remove": [
       "C:\\Users\\Public\\Desktop\\Adobe Acrobat.lnk"
     ],
-    "Copy": [],
+    "CopyFile": [],
     "Run": [
       "reg add \"HKLM\\SOFTWARE\\Policies\\Adobe\\Adobe Acrobat\\DC\\FeatureLockDown\" /v \"bIsSCReducedModeEnforcedEx\" /d 1 /t \"REG_DWORD\" /f | Out-Null",
       "reg add \"HKLM\\SOFTWARE\\Policies\\Adobe\\Adobe Acrobat\\DC\\FeatureLockDown\\cIPM\" /v \"bDontShowMsgWhenViewingDoc\" /d 0 /t \"REG_DWORD\" /f | Out-Null",

--- a/packages/App/AdobeAcrobatReaderDCMUIVDI/Source/Install.json
+++ b/packages/App/AdobeAcrobatReaderDCMUIVDI/Source/Install.json
@@ -12,7 +12,7 @@
     "Remove": [
       "C:\\Users\\Public\\Desktop\\Adobe Acrobat.lnk"
     ],
-    "Copy": [],
+    "CopyFile": [],
     "Run": [
       "Get-Service -Name \"AdobeARMservice\" -ErrorAction \"SilentlyContinue\" | Stop-Service -ErrorAction \"SilentlyContinue\"",
       "Get-Service -Name \"AdobeARMservice\" -ErrorAction \"SilentlyContinue\" | Set-Service -StartupType \"Disabled\" -ErrorAction \"SilentlyContinue\"",

--- a/packages/App/AppleMobileDeviceSupport/Source/Install.json
+++ b/packages/App/AppleMobileDeviceSupport/Source/Install.json
@@ -11,7 +11,7 @@
     "PostInstall": {
         "Remove": [
         ],
-        "Copy": [
+        "CopyFile": [
         ]
     }
 }

--- a/packages/App/Audacity/Source/Install.json
+++ b/packages/App/Audacity/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/CitrixWorkspaceAppCurrent/Source/Install.json
+++ b/packages/App/CitrixWorkspaceAppCurrent/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/CitrixWorkspaceAppLTSR/Source/Install.json
+++ b/packages/App/CitrixWorkspaceAppLTSR/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/ConnectWiseControl/Source/Install.json
+++ b/packages/App/ConnectWiseControl/Source/Install.json
@@ -11,7 +11,7 @@
     "PostInstall": {
         "Remove": [
         ],
-        "Copy": [
+        "CopyFile": [
         ]
     }
 }

--- a/packages/App/Cyberduck/Source/Install.json
+++ b/packages/App/Cyberduck/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/FoxitReader/Source/Install.json
+++ b/packages/App/FoxitReader/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/GoogleChrome/Source/Install.json
+++ b/packages/App/GoogleChrome/Source/Install.json
@@ -11,9 +11,10 @@
   },
   "PostInstall": {
     "Remove": [
-      "C:\\Users\\Public\\Desktop\\Google Chrome.lnk"
+      "C:\\Users\\Public\\Desktop\\Google Chrome.lnk",
+      "C:\\Program Files\\Google\\Chrome\\Application\\initial_preferences"
     ],
-    "Copy": [
+    "CopyFile": [
       {
         "Source": "initial_preferences.txt",
         "Destination": "C:\\Program Files\\Google\\Chrome\\Application\\initial_preferences"

--- a/packages/App/Greenshot/Source/Install.json
+++ b/packages/App/Greenshot/Source/Install.json
@@ -18,10 +18,10 @@
             "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Greenshot\\Readme.txt.lnk",
             "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Greenshot\\Uninstall Greenshot.lnk"
         ],
-        "Copy": [
+        "CopyFile": [
             {
                 "Source": "greenshot-defaults.ini",
-                "Destination": "C:\\Program Files\\Greenshot"
+                "Destination": "C:\\Program Files\\Greenshot\\greenshot-defaults.ini"
             }
         ]
     }

--- a/packages/App/ImageGlass/Source/Install.json
+++ b/packages/App/ImageGlass/Source/Install.json
@@ -14,6 +14,6 @@
       "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\ImageGlass\\ImageGlass' LICENSE.lnk",
       "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\ImageGlass\\Uninstall ImageGlass*.lnk"
     ],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/LenovoVantageService/Source/Install.json
+++ b/packages/App/LenovoVantageService/Source/Install.json
@@ -11,6 +11,6 @@
     },
     "PostInstall": {
         "Remove": [],
-        "Copy": []
+        "CopyFile": []
     }
 }

--- a/packages/App/Microsoft.NETCurrent/Source/Install.json
+++ b/packages/App/Microsoft.NETCurrent/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/Microsoft.NETLTS/Source/Install.json
+++ b/packages/App/Microsoft.NETLTS/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftEdge/Source/Install.json
+++ b/packages/App/MicrosoftEdge/Source/Install.json
@@ -13,7 +13,7 @@
       "C:\\Users\\Public\\Desktop\\Microsoft Edge.lnk",
       "C:\\Users\\Public\\Desktop\\Edge.lnk"
     ],
-    "Copy": [
+    "CopyFile": [
       {
         "Source": "initial_preferences.txt",
         "Destination": "C:\\Program Files\\Microsoft\\Edge\\Application\\initial_preferences"

--- a/packages/App/MicrosoftEdgeWebView2/Source/Install.json
+++ b/packages/App/MicrosoftEdgeWebView2/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftFSLogixApps/Source/Install.json
+++ b/packages/App/MicrosoftFSLogixApps/Source/Install.json
@@ -24,6 +24,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftOneDrive/Source/Install.json
+++ b/packages/App/MicrosoftOneDrive/Source/Install.json
@@ -13,6 +13,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftOneDriveVDI/Source/Install.json
+++ b/packages/App/MicrosoftOneDriveVDI/Source/Install.json
@@ -13,6 +13,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftPowerShell/Source/Install.json
+++ b/packages/App/MicrosoftPowerShell/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftPowerToys/Source/Install.json
+++ b/packages/App/MicrosoftPowerToys/Source/Install.json
@@ -13,6 +13,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftSsmsEnu/Source/Install.json
+++ b/packages/App/MicrosoftSsmsEnu/Source/Install.json
@@ -11,6 +11,6 @@
     },
     "PostInstall": {
         "Remove": [],
-        "Copy": []
+        "CopyFile": []
     }
 }

--- a/packages/App/MicrosoftSupportCenter/Source/Install.json
+++ b/packages/App/MicrosoftSupportCenter/Source/Install.json
@@ -10,6 +10,6 @@
     },
     "PostInstall": {
         "Remove": [],
-        "Copy": []
+        "CopyFile": []
     }
 }

--- a/packages/App/MicrosoftTeams/Source/Install.json
+++ b/packages/App/MicrosoftTeams/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftTeamsVDI/Source/Install.json
+++ b/packages/App/MicrosoftTeamsVDI/Source/Install.json
@@ -15,6 +15,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftVcRedist2012x64/Source/Install.json
+++ b/packages/App/MicrosoftVcRedist2012x64/Source/Install.json
@@ -11,6 +11,6 @@
     },
     "PostInstall": {
         "Remove": [],
-        "Copy": []
+        "CopyFile": []
     }
 }

--- a/packages/App/MicrosoftVcRedist2012x86/Source/Install.json
+++ b/packages/App/MicrosoftVcRedist2012x86/Source/Install.json
@@ -11,6 +11,6 @@
     },
     "PostInstall": {
         "Remove": [],
-        "Copy": []
+        "CopyFile": []
     }
 }

--- a/packages/App/MicrosoftVcRedist2013x64/Source/Install.json
+++ b/packages/App/MicrosoftVcRedist2013x64/Source/Install.json
@@ -11,6 +11,6 @@
     },
     "PostInstall": {
         "Remove": [],
-        "Copy": []
+        "CopyFile": []
     }
 }

--- a/packages/App/MicrosoftVcRedist2013x86/Source/Install.json
+++ b/packages/App/MicrosoftVcRedist2013x86/Source/Install.json
@@ -11,6 +11,6 @@
     },
     "PostInstall": {
         "Remove": [],
-        "Copy": []
+        "CopyFile": []
     }
 }

--- a/packages/App/MicrosoftVcRedist2022x64/Source/Install.json
+++ b/packages/App/MicrosoftVcRedist2022x64/Source/Install.json
@@ -11,6 +11,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftVcRedist2022x86/Source/Install.json
+++ b/packages/App/MicrosoftVcRedist2022x86/Source/Install.json
@@ -11,6 +11,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftVisualStudioCode/Source/Install.json
+++ b/packages/App/MicrosoftVisualStudioCode/Source/Install.json
@@ -11,6 +11,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MicrosoftWvdRemoteDesktop/Source/Install.json
+++ b/packages/App/MicrosoftWvdRemoteDesktop/Source/Install.json
@@ -11,6 +11,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/MozillaFirefox/Source/Install.json
+++ b/packages/App/MozillaFirefox/Source/Install.json
@@ -11,6 +11,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/Notepad++/Source/Install.json
+++ b/packages/App/Notepad++/Source/Install.json
@@ -11,6 +11,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/PaintDotNetOfflineInstaller/Source/Install.json
+++ b/packages/App/PaintDotNetOfflineInstaller/Source/Install.json
@@ -11,6 +11,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/ReincubateCamo/Source/Install.json
+++ b/packages/App/ReincubateCamo/Source/Install.json
@@ -11,6 +11,6 @@
     },
     "PostInstall": {
         "Remove": [],
-        "Copy": []
+        "CopyFile": []
     }
 }

--- a/packages/App/TrackerSoftwarePDFXChangeEditor/Source/Install.json
+++ b/packages/App/TrackerSoftwarePDFXChangeEditor/Source/Install.json
@@ -13,6 +13,6 @@
       "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Tracker Software\\PDF-XChange Editor",
       "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Tracker Software\\PDF-XChange Lite"
     ],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/VideoLanVlcPlayer/Source/Install.json
+++ b/packages/App/VideoLanVlcPlayer/Source/Install.json
@@ -16,6 +16,6 @@
       "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\VideoLAN\\VLC\\Documentation.lnk",
       "C:\\Users\\Public\\Desktop\\VLC media player.lnk"
     ],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/ZoomMeetings/Source/Install.json
+++ b/packages/App/ZoomMeetings/Source/Install.json
@@ -13,6 +13,6 @@
     "Remove": [
       "C:\\Users\\Public\\Desktop\\Zoom.lnk"
     ],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/App/ZoomRooms/Source/Install.json
+++ b/packages/App/ZoomRooms/Source/Install.json
@@ -11,6 +11,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/Update/AdobeAcrobatReaderDCMUIx64/Source/Install.json
+++ b/packages/Update/AdobeAcrobatReaderDCMUIx64/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/Update/AdobeAcrobatReaderDCMUIx86/Source/Install.json
+++ b/packages/Update/AdobeAcrobatReaderDCMUIx86/Source/Install.json
@@ -10,6 +10,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/Update/MicrosoftVisualStudioCode/Source/Install.json
+++ b/packages/Update/MicrosoftVisualStudioCode/Source/Install.json
@@ -11,6 +11,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/Update/MicrosoftWvdRemoteDesktop/Source/Install.json
+++ b/packages/Update/MicrosoftWvdRemoteDesktop/Source/Install.json
@@ -11,6 +11,6 @@
   },
   "PostInstall": {
     "Remove": [],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/packages/Update/ZoomMeetings/Source/Install.json
+++ b/packages/Update/ZoomMeetings/Source/Install.json
@@ -13,6 +13,6 @@
     "Remove": [
       "C:\\Users\\Public\\Desktop\\Zoom.lnk"
     ],
-    "Copy": []
+    "CopyFile": []
   }
 }

--- a/template/Source/Install.json
+++ b/template/Source/Install.json
@@ -11,7 +11,7 @@
     "PostInstall": {
         "Remove": [
         ],
-        "Copy": [
+        "CopyFile": [
         ]
     }
 }


### PR DESCRIPTION
* Fix an issue where files were not being copied by `Copy-File` by removing test for path. Ensure destination path exists before copying file during application install. Fixes #29 
* Renames `PostInstall.Copy` property to `PostInstall.CopyFile` and updates application `Install.json` files
* Updates `Uninstall-Msi` to use `Get-CimInstance` with `Win32_InstalledWin32Program` instead of `Win32_Product`. Fixes #21 