### PR TITLE
Add Verbose flag to show the download source URL

### DIFF
--- a/New-Win32Package.ps1
+++ b/New-Win32Package.ps1
@@ -241,12 +241,12 @@ process {
                     if ($Manifest.Application.Filter -match "Invoke-EvergreenApp|Get-EvergreenApp") {
                         # Evergreen
                         Write-Msg -Msg "Downloading with Evergreen to: '$SourcePath'"
-                        $Result = Invoke-Expression -Command $Manifest.Application.Filter | Save-EvergreenApp -LiteralPath $SourcePath
+                        $Result = Invoke-Expression -Command $Manifest.Application.Filter | Save-EvergreenApp -LiteralPath $SourcePath -Verbose
                     }
                     elseif ($Manifest.Application.Filter -match "Get-VcList") {
                         # VcRedist
                         Write-Msg -Msg "Downloading with Evergreen to: '$SourcePath'"
-                        $Result = Invoke-Expression -Command $Manifest.Application.Filter | Save-EvergreenApp -LiteralPath $SourcePath
+                        $Result = Invoke-Expression -Command $Manifest.Application.Filter | Save-EvergreenApp -LiteralPath $SourcePath -Verbose
                     }
                     else {
                         # Other


### PR DESCRIPTION
While most users understand the source URL is defined in Evergreen, the current packagefactory workflow does not display it.
This is just a suggestion as I'm sure there are more elegant ways of adding this into the scripts.