### PR TITLE
fix Scripts folder ref

### DIFF
--- a/scripts/Create-Win32App.ps1
+++ b/scripts/Create-Win32App.ps1
@@ -49,7 +49,7 @@ process {
     $AppSourceFolder = [System.IO.Path]::Combine($AppSourceFolder, "Source")
 
     # Required packaging variables
-    $ScriptsFolder = [System.IO.Path]::Combine($PSScriptRoot, "Scripts")
+    $ScriptsFolder = [System.IO.Path]::Combine($AppSourceFolder, "Scripts")
 
     # Icon file - download the file, if the property is a URL
     if ($AppData.PackageInformation.IconFile -match "^http") {


### PR DESCRIPTION
## Motivation

The current implementation does not meet the specifications regarding the scripts folder described at https://stealthpuppy.com/packagefactory/intunewin32/#scripts-folder. 

## Changes

I have modified the code to comply with the specified requirements.